### PR TITLE
use std::string for benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ test-with-std-move: test/test.cpp timsort.hpp .bin
 	time ./.bin/$@
 
 bench: example/bench.cpp timsort.hpp .bin
-	$(COMPILE) $(OPTIMIZE) -std=c++11 -DENABLE_STD_MOVE $< -o .bin/$@
 	$(CXX) -v
+	$(COMPILE) $(OPTIMIZE) -std=c++11 -DENABLE_STD_MOVE $< -o .bin/$@
 	./.bin/$@
 
 coverage:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `make test` for testing and `make coverage` for test coverage.
 COMPATIBILITY
 ==================
 
-This library is compatible with C++03, but if you give the `-DENABLE_STD_MOVE=1` flag to the compiler, you can sort move-only types (see [#9](https://github.com/gfx/cpp-TimSort/pull/9) for details).
+This library is compatible with C++03, but if you give the `-DENABLE_STD_MOVE` flag to the compiler, you can sort move-only types (see [#9](https://github.com/gfx/cpp-TimSort/pull/9) for details).
 
 SEE ALSO
 ==================
@@ -38,42 +38,42 @@ BENCHMARK
 bench.cpp, invoked by `make bench`, is a simple benchmark.
 An example output is as follows (timing scale: sec.):
 
-    c++ -I. -Wall -Wextra -g  -DNDEBUG -O2 -std=c++11 -DENABLE_STD_MOVE example/bench.cpp -o .bin/bench
     c++ -v
     Apple LLVM version 7.0.0 (clang-700.0.72)
     Target: x86_64-apple-darwin14.5.0
     Thread model: posix
+    c++ -I. -Wall -Wextra -g  -DNDEBUG -O2 -std=c++11 -DENABLE_STD_MOVE example/bench.cpp -o .bin/bench
     ./.bin/bench
     RANDOMIZED SEQUENCE
     [int]
     size	100000
-    std::sort        0.531996
-    std::stable_sort 0.645782
-    timsort          1.012254
-    [boost::rational]
+    std::sort        0.695253
+    std::stable_sort 0.868916
+    timsort          1.255825
+    [std::string]
     size	100000
-    std::sort        3.466250
-    std::stable_sort 5.943234
-    timsort          4.456835
+    std::sort        3.438217
+    std::stable_sort 4.122629
+    timsort          5.791845
     REVERSED SEQUENCE
     [int]
     size	100000
-    std::sort        0.023546
-    std::stable_sort 0.399995
-    timsort          0.014056
-    [boost::rational]
+    std::sort        0.045461
+    std::stable_sort 0.575431
+    timsort          0.019139
+    [std::string]
     size	100000
-    std::sort        0.626102
-    std::stable_sort 7.463993
-    timsort          0.218232
+    std::sort        0.586707
+    std::stable_sort 2.715778
+    timsort          0.345099
     SORTED SEQUENCE
     [int]
     size	100000
-    std::sort        0.015051
-    std::stable_sort 0.074084
-    timsort          0.007797
-    [boost::rational]
+    std::sort        0.021876
+    std::stable_sort 0.087993
+    timsort          0.008042
+    [std::string]
     size	100000
-    std::sort        0.371826
-    std::stable_sort 1.290227
-    timsort          0.216113
+    std::sort        0.402458
+    std::stable_sort 2.436326
+    timsort          0.298639

--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -23,7 +23,7 @@ static void bench(int const size, state_t const state) {
 
     std::vector<value_t> a;
     for(int i = 0; i < size; ++i) {
-        a.push_back((i+1) * 10);
+        a.push_back(boost::lexical_cast<value_t>((i+1) * 10));
     }
 
     switch(state) {
@@ -82,8 +82,8 @@ static void doit(int const n, state_t const state) {
     std::cerr << "[int]" << std::endl;
     bench<int>(n, state);
 
-    std::cerr << "[boost::rational]" << std::endl;
-    bench< boost::rational<long long> >(n, state);
+    std::cerr << "[std::string]" << std::endl;
+    bench<std::string>(n, state);
 }
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
This is because std::string supports move semantics whereas boost::rational (as of boost 1.58) not.