### PR TITLE
C++03/move-compliance checks

### DIFF
--- a/timsort.hpp
+++ b/timsort.hpp
@@ -31,30 +31,40 @@
 
 #include <vector>
 #include <cassert>
-#include <iterator>
-#include <algorithm>
-#include <utility>
+#include <algorithm> // std::copy
 
-#ifdef ENABLE_TIMSORT_LOG
-#include <iostream>
-#define GFX_TIMSORT_LOG(expr) (std::clog << "# " << __func__ << ": " << expr << std::endl)
+
+// If compiler supports both type traits and move semantics - will cover most but not all compilers/std libraries:
+#if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && !defined(__GNUC__)) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)))
+	#include <iterator> // iterator_traits
+	#include <utility> // std::move
+
+	#define PLF_TIMSORT_MOVE(x) (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) ? std::move(x) : (x)
+	#define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) \
+		if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
+		{ \
+			std::move((in1), (in2), (out)); \
+		} \
+		else \
+		{ \
+			std::copy((in1), (in2), (out)); \
+		}
+	#define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) \
+		if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
+		{ \
+			std::move_backward((in1), (in2), (out)); \
+		} \
+		else \
+		{ \
+			std::copy_backward((in1), (in2), (out)); \
+		}
 #else
-#define GFX_TIMSORT_LOG(expr) ((void)0)
+	#define PLF_TIMSORT_MOVE(x) (x)
+	#define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) std::copy((in1), (in2), (out));
+	#define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) std::copy_backward((in1), (in2), (out));
 #endif
 
-#if __cplusplus >= 201103L && !DISABLE_STD_MOVE
-#define ENABLE_STD_MOVE 1
-#endif
 
-#if ENABLE_STD_MOVE
-#define GFX_TIMSORT_MOVE(x) std::move(x)
-#define GFX_TIMSORT_MOVE_RANGE(in1, in2, out) std::move((in1), (in2), (out))
-#define GFX_TIMSORT_MOVE_BACKWARD(in1, in2, out) std::move_backward((in1), (in2), (out))
-#else
-#define GFX_TIMSORT_MOVE(x) (x)
-#define GFX_TIMSORT_MOVE_RANGE(in1, in2, out) std::copy((in1), (in2), (out))
-#define GFX_TIMSORT_MOVE_BACKWARD(in1, in2, out) std::copy_backward((in1), (in2), (out))
-#endif
 
 namespace gfx {
 

--- a/timsort.hpp
+++ b/timsort.hpp
@@ -33,6 +33,12 @@
 #include <cassert>
 #include <algorithm> // std::copy
 
+#ifdef ENABLE_TIMSORT_LOG
+#include <iostream>
+#define GFX_TIMSORT_LOG(expr) (std::clog << "# " << __func__ << ": " << expr << std::endl)
+#else
+#define GFX_TIMSORT_LOG(expr) ((void)0)
+#endif
 
 // If compiler supports both type traits and move semantics - will cover most but not all compilers/std libraries:
 #if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && !defined(__GNUC__)) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)))

--- a/timsort.hpp
+++ b/timsort.hpp
@@ -5,7 +5,7 @@
  * - http://svn.python.org/projects/python/trunk/Objects/listobject.c
  * - http://cr.openjdk.java.net/~martin/webrevs/openjdk7/timsort/raw_files/new/src/share/classes/java/util/TimSort.java
  *
- * Copyright (c) 2011 Fuji, Goro (gfx) <gfuji@cpan.org>. C++03/move-compliance modifications by Matt Bentley 2017 (plflib.org, mattreecebentley@gmail.com)
+ * Copyright (c) 2011 Fuji, Goro (gfx) <gfuji@cpan.org>. C++03/move-compliance modifications by Matt Bentley 2017 (mattreecebentley@gmail.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -41,33 +41,33 @@
 #endif
 
 // If compiler supports both type traits and move semantics - will cover most but not all compilers/std libraries:
-#if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (!defined(__GNUC__) || ((defined(__clang__) || __GNUC__ >= 5) && (!defined(__GLIBCXX__) || __GLIBCXX__ >= 20150422)))
-	#include <iterator> // iterator_traits
-	#include <utility> // std::move
+#if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (!defined(__GNUC__) || ((defined(__clang__) || __GNUC__ >= 5) && (!defined(__GLIBCXX__) || __GLIBCXX__ >= 20150422))))
+    #include <iterator> // iterator_traits
+    #include <utility> // std::move
 
-	#define PLF_TIMSORT_MOVE(x) (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) ? std::move(x) : (x)
-	#define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) \
-		if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
-		{ \
-			std::move((in1), (in2), (out)); \
-		} \
-		else \
-		{ \
-			std::copy((in1), (in2), (out)); \
-		}
-	#define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) \
-		if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
-		{ \
-			std::move_backward((in1), (in2), (out)); \
-		} \
-		else \
-		{ \
-			std::copy_backward((in1), (in2), (out)); \
-		}
+    #define PLF_TIMSORT_MOVE(x) (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) ? std::move(x) : (x)
+    #define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) \
+        if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
+        { \
+            std::move((in1), (in2), (out)); \
+        } \
+        else \
+        { \
+            std::copy((in1), (in2), (out)); \
+        }
+    #define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) \
+        if (std::is_move_constructible<value_t>::value && std::is_move_assignable<value_t>::value) \
+        { \
+            std::move_backward((in1), (in2), (out)); \
+        } \
+        else \
+        { \
+            std::copy_backward((in1), (in2), (out)); \
+        }
 #else
-	#define PLF_TIMSORT_MOVE(x) (x)
-	#define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) std::copy((in1), (in2), (out));
-	#define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) std::copy_backward((in1), (in2), (out));
+    #define PLF_TIMSORT_MOVE(x) (x)
+    #define PLF_TIMSORT_MOVE_RANGE(in1, in2, out) std::copy((in1), (in2), (out));
+    #define PLF_TIMSORT_MOVE_BACKWARD(in1, in2, out) std::copy_backward((in1), (in2), (out));
 #endif
 
 

--- a/timsort.hpp
+++ b/timsort.hpp
@@ -5,7 +5,7 @@
  * - http://svn.python.org/projects/python/trunk/Objects/listobject.c
  * - http://cr.openjdk.java.net/~martin/webrevs/openjdk7/timsort/raw_files/new/src/share/classes/java/util/TimSort.java
  *
- * Copyright (c) 2011 Fuji, Goro (gfx) <gfuji@cpan.org>.
+ * Copyright (c) 2011 Fuji, Goro (gfx) <gfuji@cpan.org>. C++03/move-compliance modifications by Matt Bentley 2017 (plflib.org, mattreecebentley@gmail.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -41,7 +41,7 @@
 #endif
 
 // If compiler supports both type traits and move semantics - will cover most but not all compilers/std libraries:
-#if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && !defined(__GNUC__)) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)))
+#if (defined(_MSC_VER) && _MSC_VER >= 1700) || ((defined(__cplusplus) && __cplusplus >= 201103L) && (!defined(__GNUC__) || ((defined(__clang__) || __GNUC__ >= 5) && (!defined(__GLIBCXX__) || __GLIBCXX__ >= 20150422)))
 	#include <iterator> // iterator_traits
 	#include <utility> // std::move
 


### PR DESCRIPTION
Additional checks on compiler move/type-trait compliance, check for move capability of element type (these checks are compile-time and should be optimized out by compiler), fallback to copy for non-move-capable types.